### PR TITLE
Fix val_loss not referencing a variable

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -327,7 +327,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
 
                 # implement your own
                 out = self.forward(x)
-                loss = self.loss(out, y)
+                val_loss = self.loss(out, y)
 
                 # log 6 example images
                 # or generated text... or whatever


### PR DESCRIPTION
In validation step, the val_loss variable does not reference a declared variable in the example.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
